### PR TITLE
Bug/there-is-a-no-sense-update-content-title-in-feedback-create-form

### DIFF
--- a/src/app/modules/feedback/layouts/feedback-form/feedback-form.component.html
+++ b/src/app/modules/feedback/layouts/feedback-form/feedback-form.component.html
@@ -27,7 +27,7 @@
                 </ui-select>
             </ui-form-field>
 
-            <h4 class="form-field-title">Update status</h4>
+            <h4 class="form-field-title" *ngIf="update">Update status</h4>
             <ui-form-field size="fluent" *ngIf="update">
                 <ui-label>{{ t('formFields.statusLabel') }}</ui-label>
                 <ui-select [formControl]="statusControl">


### PR DESCRIPTION
When a user is creating a feedback there is a missing title that belongs to the update form. The form is reusable and in this case is being used for both views: create and update.

Approved by: Godm0de