### PR TITLE
Bug/when-there-is-no-comments-in-a-feedback-detail-there-is-a-empty-container

### DIFF
--- a/src/app/modules/feedback/layouts/feedback-detail/feedback-detail.component.html
+++ b/src/app/modules/feedback/layouts/feedback-detail/feedback-detail.component.html
@@ -20,7 +20,7 @@
         </div>
         <ui-chip feedback-card-footer [selectable]="false">{{ feedback.category | titlecase }}</ui-chip>
     </app-feedback-card>
-    <section class="comment-section">
+    <section class="comment-section" *ngIf="feedback.comments">
         <div *ngFor="let comment of feedback.comments; let i = index">
             <app-comment>
                 <img src="{{ comment.user.image }}" alt="{{ comment.user.name }}" comment-avatar />


### PR DESCRIPTION
When there is a feedback detail without comments an empty container was rendered. Now this container will be rendered if there is comments defined in this feedback detail.